### PR TITLE
add `load-tsconfig` to load tsconfig including `extends`

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "devDependencies": {
     "@types/node": "^22.8.1",
     "esbuild": "^0.24.0",
+    "load-tsconfig": "^0.2.5",
     "tsc-alias": "^1.8.10",
     "tsup": "^8.3.5",
     "typescript": "^5.6.3"


### PR DESCRIPTION
Properly resolve `tsconfig` that are using `extends`. Fixes https://github.com/aymericzip/esbuild-fix-imports-plugin/issues/8#issue-2916060905