### PR TITLE
fix: replace extension when import path uses explicit .js extension

### DIFF
--- a/src/fixExtensionsPlugin.ts
+++ b/src/fixExtensionsPlugin.ts
@@ -60,10 +60,15 @@ const CJS_RELATIVE_IMPORT_EXP = /require\s*\(\s*["'](\..+?)["']\s*\)(;?)/g;
 const ESM_RELATIVE_IMPORT_EXP = /from\s*(["'])(\.[^"']+)\1([^;]*;?)/g;
 
 /**
- * Regular expression to detect if the import path already has an extension,
+ * Regular expression to detect if the import path already contains an explicit .js extension
+ */
+const hasJSExtensionsRegex = /\.(?:js)$/i;
+
+/**
+ * Regular expression to detect if the import path already has an extension (that is not .js),
  * such as .png, .svg, .jpeg, .jpg, etc.
  */
-const hasExtensionRegex =
+const hasNonJSExtensionRegex =
   /\.(?:png|svg|css|scss|csv|tsv|xml|toml|ini|jpe?g|json|md|mdx|json|yaml|gif|webp|ico|mp4|webm|ogg|wav|mp3|m4a|aac|webm|woff2?|eot|ttf|otf|wasm)$/i;
 
 /**
@@ -105,8 +110,17 @@ const modifyEsmImports = (contents: string, outExtension: string) => {
         return `from ${quote}${importPath}${quote}${rest}`;
       }
 
+      // If the import path has an explicit .js extension and the out extension is different, replace the existing extension.
+      if (hasJSExtensionsRegex.test(importPath) && outExtension !== ".js") {
+        const updatedImportPath = importPath.replace(
+          hasJSExtensionsRegex,
+          outExtension
+        );
+        return `from ${quote}${updatedImportPath}${quote}${rest}`;
+      }
+
       // If the import path has an existing extension (e.g., .png, .svg), leave it as is.
-      if (hasExtensionRegex.test(importPath)) {
+      if (hasNonJSExtensionRegex.test(importPath)) {
         return `from ${quote}${importPath}${quote}${rest}`;
       }
 
@@ -133,13 +147,22 @@ const modifyCjsImports = (contents: string, outExtension: string) => {
         return `require('${importPath}/index${outExtension}')${maybeSemicolon}`;
       }
 
+      // If the import path has an explicit .js extension and the out extension is different, replace the existing extension.
+      if (hasJSExtensionsRegex.test(importPath) && outExtension !== ".js") {
+        const updatedImportPath = importPath.replace(
+          hasJSExtensionsRegex,
+          outExtension
+        );
+        return `require('${updatedImportPath}')${maybeSemicolon}`;
+      }
+
       // If the import path already ends with '.cjs', leave it as is.
       if (importPath.endsWith(outExtension)) {
         return `require('${importPath}')${maybeSemicolon}`;
       }
 
       // If the import path has an existing extension (e.g., .png, .svg), leave it as is.
-      if (hasExtensionRegex.test(importPath)) {
+      if (hasNonJSExtensionRegex.test(importPath)) {
         return `require('${importPath}')${maybeSemicolon}`;
       }
 

--- a/src/fixExtensionsPlugin.ts
+++ b/src/fixExtensionsPlugin.ts
@@ -62,7 +62,7 @@ const ESM_RELATIVE_IMPORT_EXP = /from\s*(["'])(\.[^"']+)\1([^;]*;?)/g;
 /**
  * Regular expression to detect if the import path already contains an explicit .js extension
  */
-const hasJSExtensionsRegex = /\.(?:js)$/i;
+const hasJSExtensionRegex = /\.(?:js)$/i;
 
 /**
  * Regular expression to detect if the import path already has an extension (that is not .js),
@@ -111,9 +111,9 @@ const modifyEsmImports = (contents: string, outExtension: string) => {
       }
 
       // If the import path has an explicit .js extension and the out extension is different, replace the existing extension.
-      if (hasJSExtensionsRegex.test(importPath) && outExtension !== ".js") {
+      if (hasJSExtensionRegex.test(importPath) && outExtension !== ".js") {
         const updatedImportPath = importPath.replace(
-          hasJSExtensionsRegex,
+          hasJSExtensionRegex,
           outExtension
         );
         return `from ${quote}${updatedImportPath}${quote}${rest}`;
@@ -148,9 +148,9 @@ const modifyCjsImports = (contents: string, outExtension: string) => {
       }
 
       // If the import path has an explicit .js extension and the out extension is different, replace the existing extension.
-      if (hasJSExtensionsRegex.test(importPath) && outExtension !== ".js") {
+      if (hasJSExtensionRegex.test(importPath) && outExtension !== ".js") {
         const updatedImportPath = importPath.replace(
-          hasJSExtensionsRegex,
+          hasJSExtensionRegex,
           outExtension
         );
         return `require('${updatedImportPath}')${maybeSemicolon}`;

--- a/test/src/file.js
+++ b/test/src/file.js
@@ -1,0 +1,1 @@
+export const test = "test";

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -1,3 +1,5 @@
 import { test } from "./subpath";
+import { test as jsTest } from "./file.js";
 
 console.log(test);
+console.log(jsTest);


### PR DESCRIPTION
Fixes #1 

Ideally there's a test command to run to confirm that this is fixed. All I did was update the test directory to provide an example of where the issue occurs and then compared the outputs of `npx tsup` between the main branch and this branch 😄 